### PR TITLE
Fix repo cd command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ FINANCIAL_DATASET_API_KEY=your_financial_dataset_key
 1. **Clone the repository**
    ```bash
    git clone <repository-url>
-   cd high-dividend-ai
+   cd High-dividend-AI
    ```
 
 2. **Install dependencies**


### PR DESCRIPTION
## Summary
- update the README installation instructions to use `cd High-dividend-AI`

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_685572dfd180833389d0d6abed35df55